### PR TITLE
client: Add stream feature

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
 
 export * from './client';
+export * from './mongo-read-stream';
 export * from './mongo-utils';

--- a/src/mongo-read-stream.ts
+++ b/src/mongo-read-stream.ts
@@ -1,0 +1,122 @@
+import { Readable, Writable } from 'stream';
+import { MongoClient } from './client';
+import { MongoUtils } from './mongo-utils';
+import { BaseMongoObject } from "./models";
+
+export type PageConsumer<T> = (data: T[]) => Promise<void>;
+export type ItemConsumer<T> = (data: T) => Promise<void>;
+
+export class PageConsumerWritable<T> extends Writable {
+
+	private buffer: T[] = [];
+
+	constructor(
+		private pageSize: number,
+		private consumerFn: PageConsumer<T>) {
+		super({ objectMode: true });
+	}
+
+	public async _write(chunk: T, encoding: string, callback?: (error?: any) => void): Promise<boolean> {
+		try {
+			this.buffer.push(chunk);
+			if (this.buffer.length >= this.pageSize) {
+				await this.consumerFn(this.buffer);
+				this.buffer = [];
+			}
+		} catch (err) {
+			callback(err);
+			return;
+		}
+		callback();
+	}
+
+	public async _final(callback: (error?: Error | null) => void): Promise<void> {
+		if (this.buffer.length) await this.consumerFn(this.buffer);
+		callback();
+	}
+}
+
+export class ItemConsumerWritable<T> extends Writable {
+	constructor(private consumerFn: ItemConsumer<T>) {
+		super({ objectMode: true });
+	}
+
+	public async _write(chunk: T, encoding: string, callback?: (error?: any) => void): Promise<boolean> {
+		try {
+			await this.consumerFn(chunk);
+		} catch (err) {
+			callback(err);
+			return;
+		}
+		callback();
+	}
+}
+
+/**
+ * Readable stream that streams the content of a collection.
+ * This stream implement pagination without using cursor.skip() but rather by using limit and a comparison
+ * with _id. This behaviour has better performance when reading large collections.
+ */
+export class MongoReadStream<T extends BaseMongoObject, U extends BaseMongoObject> extends Readable {
+
+	private first: boolean = true;
+	private lastId: string = null;
+
+	constructor(
+		private mongoClient: MongoClient<T, U>,
+		private query: object,
+		private pageSize: number,
+		private projection: object = {}) {
+		super({ objectMode: true });
+	}
+
+	/**
+	 * Call the given callback for each page in series
+	 * Return a promise that is resolved when all the items have been consumed
+	 */
+	public async forEachPage(consumerFn: PageConsumer<U>): Promise<void> {
+		return new Promise<void>((resolve, reject) => {
+			this.pipe(new PageConsumerWritable(this.pageSize, consumerFn))
+				.on("error", reject)
+				.on("finish", resolve);
+		});
+	}
+
+	/**
+	 * Call the given callback for each item in series
+	 * Return a promise that is resolved when all the items have been consumed
+	 */
+	public async forEach(consumerFn: ItemConsumer<U>): Promise<void> {
+		return new Promise<void>((resolve, reject) => {
+			this.pipe(new ItemConsumerWritable(consumerFn))
+				.on("error", reject)
+				.on("finish", resolve);
+		});
+	}
+
+	public async _read(size: number): Promise<void> {
+		if (this.first) {
+			this.first = false;
+		} else {
+			(this.query as any)['_id'] = { $gt: MongoUtils.oid(this.lastId) };
+		}
+
+		const cursor = await this.mongoClient.find(this.query, 0, this.pageSize, { _id: 1 }, this.projection);
+		let resultLength = 0;
+		let item = null;
+		while (await cursor.hasNext()) {
+			resultLength++;
+
+			item = await cursor.next();
+			if (item != null) this.push(item);
+		}
+		if (item != null) {
+			this.lastId = item._id;
+		}
+
+		if (resultLength < this.pageSize) {
+			this.push(null);
+		}
+	}
+
+}

--- a/test/tests/mongo-read-stream.ts
+++ b/test/tests/mongo-read-stream.ts
@@ -1,0 +1,79 @@
+import { N9Log } from '@neo9/n9-node-log';
+import test, { Assertions } from 'ava';
+import * as mongodb from 'mongodb';
+
+import { MongoClient, MongoUtils } from '../../src';
+import { BaseMongoObject } from '../../src/models';
+
+export class TestItem extends BaseMongoObject {
+	public key: string;
+}
+
+global.log = new N9Log('tests').module('mongo-read-stream');
+
+test.before(async () => {
+	await MongoUtils.connect('mongodb://localhost:27017/test-n9-mongo-client');
+});
+
+test.after(async () => {
+	global.log.info(`DROP DB after tests OK`);
+	await (global.db as mongodb.Db).dropDatabase();
+	await MongoUtils.disconnect();
+});
+
+test('[MONGO-READ-STREAM] Read page by page', async (t: Assertions) => {
+	const mongoClient = new MongoClient('test-' + Date.now(), TestItem, TestItem);
+
+	await Promise.all(
+		new Array(38).fill(0)
+			.map(async () => mongoClient.insertOne({ key: 'value-' + Math.random() }, 'userId1', false))
+	);
+
+	let length = 0;
+	let pages = 0;
+	await mongoClient.stream({}, 10).forEachPage(async (page: TestItem[]) => {
+		length += page.length;
+		pages++;
+	});
+
+	t.is(length, 38, 'nb elements in collection');
+	t.is(pages, 4, 'nb pages in collection');
+	await mongoClient.dropCollection();
+});
+
+test('[MONGO-READ-STREAM] Read page by page on empty collection', async (t: Assertions) => {
+	const mongoClient = new MongoClient('test-' + Date.now(), TestItem, TestItem);
+
+	await mongoClient.stream({}, 10).forEachPage(async (page: TestItem[]) => {
+		t.fail('should never be called');
+	});
+
+	t.pass('ok');
+});
+
+test('[MONGO-READ-STREAM] Read item by item', async (t: Assertions) => {
+	const mongoClient = new MongoClient('test-' + Date.now(), TestItem, TestItem);
+
+	await Promise.all(
+		new Array(38).fill(0)
+			.map(async () => mongoClient.insertOne({ key: 'value-' + Math.random() }, 'userId1', false))
+	);
+
+	let length = 0;
+	await mongoClient.stream({}, 10).forEach(async (item: TestItem) => {
+		length++;
+	});
+
+	t.is(length, 38, 'nb elements in collection');
+	await mongoClient.dropCollection();
+});
+
+test('[MONGO-READ-STREAM] Read item by item on empty collection', async (t: Assertions) => {
+	const mongoClient = new MongoClient('test-' + Date.now(), TestItem, TestItem);
+
+	await mongoClient.stream({}, 10).forEach(async (item: TestItem) => {
+		t.fail('should never be called');
+	});
+
+	t.pass('ok');
+});


### PR DESCRIPTION
This pull request adds a `stream` method to `MongoClient` that returns a `MongoReadStream` that will stream a query results. The results are paginated using the `{ _id: { $gt: lastId } }` method; this method has  good performance over large collections.
`MongoReadStream` is a stream that can be consumed like a normal nodejs stream and it also exposes two helper methods:
* `forEachPage`: applies a callback for each documents page 
* `forEach` : applies a callback for each document

Resources:
https://arpitbhayani.me/techie/benchmark-and-compare-pagination-approach-in-mongodb.html
https://arpitbhayani.me/techie/fast-and-efficient-pagination-in-mongodb.html