### PR TITLE
mongo: Fix primitive type mapping

### DIFF
--- a/src/mongo-utils.ts
+++ b/src/mongo-utils.ts
@@ -57,7 +57,7 @@ export class MongoUtils {
 	}
 
 	public static removeSpecialCharactersInKeys(obj: any): any {
-		if (_.isNil(obj) || _.isString(obj) || obj instanceof ObjectID || obj instanceof Date) return obj;
+		if (_.isNil(obj) || _.isString(obj) || _.isBoolean(obj) || _.isNumber(obj) || obj instanceof ObjectID || _.isDate(obj)) return obj;
 
 		if (_.isArray(obj)) {
 			return obj.map((element) => this.removeSpecialCharactersInKeys(element));
@@ -73,7 +73,7 @@ export class MongoUtils {
 	}
 
 	public static unRemoveSpecialCharactersInKeys(obj: any): any {
-		if (_.isNil(obj) || _.isString(obj) || obj instanceof ObjectID || obj instanceof Date) return obj;
+		if (_.isNil(obj) || _.isString(obj) || _.isBoolean(obj) || _.isNumber(obj) || obj instanceof ObjectID || _.isDate(obj)) return obj;
 
 		if (_.isArray(obj)) {
 			return obj.map((element) => this.unRemoveSpecialCharactersInKeys(element));

--- a/test/tests/issues/issue-invalid-primitive-mapping.ts
+++ b/test/tests/issues/issue-invalid-primitive-mapping.ts
@@ -1,0 +1,48 @@
+import { N9Log } from '@neo9/n9-node-log';
+import test, { Assertions } from 'ava';
+import * as mongodb from 'mongodb';
+import * as _ from 'lodash';
+
+import { MongoClient, MongoUtils } from '../../../src';
+import { BaseMongoObject } from '../../../src/models';
+
+global.log = new N9Log('tests').module('issues');
+
+class PrimitiveArrayHolder extends BaseMongoObject {
+	public booleanArray: boolean[];
+	public numberArray: number[];
+	public stringArray: string[];
+}
+
+test.before(async () => {
+	await MongoUtils.connect('mongodb://localhost:27017/test-n9-mongo-client');
+});
+
+test.after(async () => {
+	global.log.info(`DROP DB after tests OK`);
+	await (global.db as mongodb.Db).dropDatabase();
+	await MongoUtils.disconnect();
+});
+
+test('[ISSUE-INVALID-PRIMITIVE-VALUE] Primitive should be mapped correctly', async (t: Assertions) => {
+	const mongoClient = new MongoClient('test-' + Date.now(), PrimitiveArrayHolder, PrimitiveArrayHolder);
+
+	const initialValue: PrimitiveArrayHolder = {
+		booleanArray: [true, false],
+		numberArray: [42, 3.14],
+		stringArray: ["xxx", "yyy"]
+	};
+
+	const savedObject = await mongoClient.insertOne(_.cloneDeep(initialValue), 'userId1', false);
+	const foundObject = await mongoClient.findOneById(savedObject._id);
+
+	t.deepEqual(savedObject.booleanArray, initialValue.booleanArray);
+	t.deepEqual(savedObject.numberArray, initialValue.numberArray);
+	t.deepEqual(savedObject.stringArray, initialValue.stringArray);
+
+	t.deepEqual(foundObject.booleanArray, initialValue.booleanArray);
+	t.deepEqual(foundObject.numberArray, initialValue.numberArray);
+	t.deepEqual(foundObject.stringArray, initialValue.stringArray);
+
+	await mongoClient.dropCollection();
+});


### PR DESCRIPTION
There is a problem when unescaping special characters (ie: `$` and `.`): some primitive values are mapped to `{}`, when they are contained in array.

For example, the output of this code:
```
console.log(unRemoveSpecialCharactersInKeys(123));
console.log(unRemoveSpecialCharactersInKeys([123]));
console.log(unRemoveSpecialCharactersInKeys({ test: [123] }));
console.log(unRemoveSpecialCharactersInKeys({ test: 123 }));

console.log(unRemoveSpecialCharactersInKeys(true));
console.log(unRemoveSpecialCharactersInKeys([true]));
console.log(unRemoveSpecialCharactersInKeys({ test: [true] }));
console.log(unRemoveSpecialCharactersInKeys({ test: true }));
```
is the following:
```
{}
[ {} ]
{ test: [ {} ] }
{ test: 123 }
{}
[ {} ]
{ test: [ {} ] }
{ test: true }
```
but it should be:
```
123
[ 123 ]
{ test: [ 123 ] }
{ test: 123 }
true
[ true ]
{ test: [ true ] }
{ test: true }
```

This pull request fixes this issue.
