### PR TITLE
client: Use options params for updateManyAtOnce

### DIFF
--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -3,4 +3,5 @@ export * from './base-mongo-object-infos.models';
 export * from './historic.models';
 export * from './lock-field.models';
 export * from './maps.models';
+export * from './update-many-at-once-options.models';
 export * from './update-many-query.models';

--- a/src/models/update-many-at-once-options.models.ts
+++ b/src/models/update-many-at-once-options.models.ts
@@ -1,0 +1,45 @@
+import { FilterQuery } from 'mongodb';
+
+export interface UpdateManyAtOnceOptions<U> {
+	/**
+	 * If true, entities that do not already exist in database will be created.
+	 * Defaults to false.
+	 */
+	upsert?: boolean;
+	/**
+	 * If true, all fields added in the entities will be locked (ie: added to the lock fields).
+	 * Defaults to true.
+	 */
+	lockNewFields?: boolean;
+	/**
+	 * - If it's a string, it will be treated as a field name to use to retrieve the existing values of the entities in database.
+	 * The value for this field will be taken from the given entities.
+	 * - If it's a function, it will be called with the given value for the entity
+	 * and its return value will be the query used to get the existing value for that entity
+	 * - If it's null or undefined, the existing version of the entity will not be retrieved from database.
+	 * Defaults to undefined.
+	 */
+	query?: string | ((entity: Partial<U>) => FilterQuery<Partial<U>>);
+	/**
+	 * Function that will be used to map the entity with its existing value.
+	 * The function will be called with the given entity and the existing entity if there is one.
+	 * Defaults to undefined (no mapping).
+	 */
+	mapFunction?: (entity: Partial<U>, existingEntity?: U) => Promise<Partial<U>>;
+	/**
+	 * List of field keys in the entities that will only be added upon insertion.
+	 * Defaults to undefined.
+	 */
+	onlyInsertFieldsKey?: string[];
+	/**
+	 * If true, the lock fields will be ignored and the entity will be updated with these fields.
+	 * If false, the lock fields will be removed from the entities so the entity will not be updated with these fields.
+	 * Defaults to false.
+	 */
+	forceEditLockFields?: boolean;
+	/**
+	 * If true, all fields that are present in the existing values and not in the given entities wil be unset in database.
+	 * Defaults to true.
+	 */
+	unsetUndefined?: boolean;
+}

--- a/test/tests/issues/issue-#1.ts
+++ b/test/tests/issues/issue-#1.ts
@@ -58,7 +58,11 @@ test('[ISSUE#1] updateManyAtOnce should remove properties if not specified', asy
 	t.is(foundObject.field5, 'string5', 'found right element string5');
 
 	global.log.debug(`updateManyAtOnce with savedObject without field1String field`);
-	const updateArray = await (await mongoClient.updateManyAtOnce([newValue], 'userId1', true, false, 'code')).toArray();
+	const updateArray = await (await mongoClient.updateManyAtOnce([newValue], 'userId1', {
+		upsert: true,
+		lockNewFields: false,
+		query: 'code',
+	})).toArray();
 
 	const updatedObject = updateArray[0];
 
@@ -106,7 +110,11 @@ test('[ISSUE#1] updateManyAtOnce should remove recursively properties if not spe
 	t.is(foundObject.sub.field4, 'string4', 'found right element string4');
 
 	global.log.debug(`updateManyAtOnce with savedObject without field1String field`);
-	const updateArray = await (await mongoClient.updateManyAtOnce([newValue], 'userId1', true, false, 'code')).toArray();
+	const updateArray = await (await mongoClient.updateManyAtOnce([newValue], 'userId1', {
+		upsert: true,
+		lockNewFields: false,
+		query: 'code',
+	})).toArray();
 
 	const updatedObject = updateArray[0];
 

--- a/test/tests/lock-fields-arrays-a.ts
+++ b/test/tests/lock-fields-arrays-a.ts
@@ -5,6 +5,7 @@ import * as mongodb from 'mongodb';
 import { MongoClient, MongoUtils } from '../../src';
 import { BaseMongoObject, StringMap } from '../../src/models';
 import { generateMongoClient, init, SampleEntityWithArray } from './fixtures/utils';
+import { UpdateManyAtOnceOptions } from '../../src/models/update-many-at-once-options.models';
 
 global.log = new N9Log('tests').module('lock-fields-arrays');
 
@@ -68,7 +69,11 @@ test('[LOCK-FIELDS-ARRAY A] Import, remove one, import others, import new one', 
 	const mongoClient = generateMongoClient();
 
 	// Simulate import
-	const resultImport1: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vA], 'externalUser', true, false, 'code')).toArray();
+	const resultImport1: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vA], 'externalUser', {
+		upsert: true,
+		lockNewFields: false,
+		query: 'code',
+	})).toArray();
 	t.deepEqual(_.map(resultImport1[0].parameters.items, 'code'), ['a', 'b', 'c'], '[resultImport1] All values saved');
 
 	const vAp = _.cloneDeep(vA);
@@ -86,7 +91,11 @@ test('[LOCK-FIELDS-ARRAY A] Import, remove one, import others, import new one', 
 	const vApp = _.cloneDeep(vA);
 	vApp.parameters.items = [a, c];
 
-	const resultImport2: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vApp], 'externalUser', true, false, 'code')).toArray();
+	const resultImport2: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vApp], 'externalUser', {
+		upsert: true,
+		lockNewFields: false,
+		query: 'code',
+	})).toArray();
 
 	t.truthy(resultImport2[0].objectInfos.lockFields, '[resultImport2] Has lock fields');
 	t.is(resultImport2[0].objectInfos.lockFields.length, 4, '[resultImport2] a and b are still locked, nothing changed');
@@ -96,7 +105,11 @@ test('[LOCK-FIELDS-ARRAY A] Import, remove one, import others, import new one', 
 	const vAppp = _.cloneDeep(vA);
 	vAppp.parameters.items = [a, c, d];
 
-	const resultImport3: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vAppp], 'externalUser', true, false, 'code')).toArray();
+	const resultImport3: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vAppp], 'externalUser', {
+		upsert: true,
+		lockNewFields: false,
+		query: 'code',
+	})).toArray();
 	t.truthy(resultImport3[0].objectInfos.lockFields, '[resultImport3] Stil has lock fields');
 	t.is(resultImport3[0].objectInfos.lockFields.length, 4, '[resultImport3] a and b are still locked, nothing changed');
 	t.deepEqual(_.map(resultImport3[0].objectInfos.lockFields, 'path'), aAndbLockPaths, '[resultImport3] a and b are locked');
@@ -105,7 +118,11 @@ test('[LOCK-FIELDS-ARRAY A] Import, remove one, import others, import new one', 
 	const vApppp = _.cloneDeep(vA);
 	vApppp.parameters.items = [a, d];
 
-	const resultImport4: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vApppp], 'externalUser', true, false, 'code')).toArray();
+	const resultImport4: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vApppp], 'externalUser', {
+		upsert: true,
+		lockNewFields: false,
+		query: 'code',
+	})).toArray();
 	t.truthy(resultImport4[0].objectInfos.lockFields, '[resultImport4] Stil has lock fields');
 	t.is(resultImport4[0].objectInfos.lockFields.length, 4, '[resultImport4] a and b are still locked, nothing changed');
 	t.deepEqual(_.map(resultImport4[0].objectInfos.lockFields, 'path'), aAndbLockPaths, '[resultImport4] a and b are locked');

--- a/test/tests/lock-fields-arrays-b.ts
+++ b/test/tests/lock-fields-arrays-b.ts
@@ -71,7 +71,11 @@ test('[LOCK-FIELDS-ARRAY B] Import, edit one, change order, re-import datas', as
 	const mongoClient = generateMongoClient();
 
 	// Simulate import
-	const resultImport1: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vB], 'externalUser', true, false, 'code')).toArray();
+	const resultImport1: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vB], 'externalUser', {
+		upsert: true,
+		lockNewFields: false,
+		query: 'code',
+	})).toArray();
 	t.deepEqual(_.map(resultImport1[0].parameters.items, 'code'), ['a', 'b', 'c'], '[resultImport1] All values saved');
 
 	const vBp = _.cloneDeep(vB);
@@ -89,7 +93,11 @@ test('[LOCK-FIELDS-ARRAY B] Import, edit one, change order, re-import datas', as
 	const vBpp = _.cloneDeep(vB);
 	vBpp.parameters.items = [b, c, a];
 	// Simulate import
-	const resultImport2: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vBpp], 'externalUser', true, false, 'code')).toArray();
+	const resultImport2: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vBpp], 'externalUser', {
+		upsert: true,
+		lockNewFields: false,
+		query: 'code',
+	})).toArray();
 	t.deepEqual(_.map(resultImport2[0].parameters.items, 'code'), ['c', 'b', 'a'], '[resultImport2] All values saved');
 	t.deepEqual(_.map(resultImport2[0].objectInfos.lockFields, 'path'), bLockPaths, '[resultImport2] Lock field b still alone');
 	t.deepEqual(resultImport2[0].parameters.items[1], bp, '[resultImport2] bp Label kept');

--- a/test/tests/lock-fields-arrays-c-d.ts
+++ b/test/tests/lock-fields-arrays-c-d.ts
@@ -56,7 +56,11 @@ test('[LOCK-FIELDS-ARRAY C] Import twice should remove element', async (t: Asser
 	const mongoClient = generateMongoClient();
 
 	// Simulate import
-	const resultImport1: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vC], 'externalUser', true, false, 'code')).toArray();
+	const resultImport1: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vC], 'externalUser', {
+		upsert: true,
+		lockNewFields: false,
+		query: 'code',
+	})).toArray();
 	t.is(resultImport1[0].objectInfos.lockFields, undefined, '[resultImport1] Has no lock fields');
 	t.deepEqual(_.map(resultImport1[0].parameters.items, 'code'), ['a', 'b', 'c'], '[resultImport1] All values saved');
 
@@ -65,7 +69,11 @@ test('[LOCK-FIELDS-ARRAY C] Import twice should remove element', async (t: Asser
 	vCp.parameters.items = [a, b];
 
 	// Simulate import
-	const resultImport2: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vCp], 'externalUser', true, false, 'code')).toArray();
+	const resultImport2: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vCp], 'externalUser', {
+		upsert: true,
+		lockNewFields: false,
+		query: 'code',
+	})).toArray();
 	t.is(resultImport2[0].objectInfos.lockFields, undefined, '[resultImport2] Has no lock fields');
 	t.deepEqual(_.map(resultImport2[0].parameters.items, 'code'), ['a', 'b'], '[resultImport2] All values saved');
 });
@@ -96,7 +104,11 @@ test('[LOCK-FIELDS-ARRAY D] Lock fields order should be keept', async (t: Assert
 	vDp.parameters.items = _.cloneDeep([c, a, b, d]);
 
 	// Simulate import
-	const resultImport1: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vDp], 'externalUser', true, false, 'code')).toArray();
+	const resultImport1: SampleEntityWithArray[] = await (await mongoClient.updateManyAtOnce([vDp], 'externalUser', {
+		upsert: true,
+		lockNewFields: false,
+		query: 'code',
+	})).toArray();
 	t.truthy(entityCreated.objectInfos.lockFields, '[resultImport1] Has lock fields');
 	t.deepEqual(_.map(resultImport1[0].parameters.items, 'code'), ['a', 'b', 'c', 'd'], '[resultImport1] Order respected');
 });

--- a/test/tests/lock-fields.ts
+++ b/test/tests/lock-fields.ts
@@ -261,7 +261,7 @@ test('[LOCK-FIELDS] Update many with locks', async (t: Assertions) => {
 		},
 	}];
 
-	await mongoClient.updateManyAtOnce(newValues, 'userId', false, true, 'text');
+	await mongoClient.updateManyAtOnce(newValues, 'userId', { query: 'text', });
 	const listing: Partial<SampleComplexType>[] = await (await mongoClient.find({}, 0, 0)).toArray();
 
 	t.is(listing.length, 2, 'found 2 elements');
@@ -376,7 +376,11 @@ test('[LOCK-FIELDS] Insert&update boolean', async (t: Assertions) => {
 		keepHistoric: true,
 	});
 
-	const attributesCreated: AttributeEntity[] = await (await mongoClient.updateManyAtOnce([attribute], 'userId1', true, false, 'code')).toArray();
+	const attributesCreated: AttributeEntity[] = await (await mongoClient.updateManyAtOnce([attribute], 'userId1', {
+		upsert: true,
+		lockNewFields: false,
+		query: 'code',
+	})).toArray();
 
 	const newAttributeValue = _.cloneDeep(attribute);
 	newAttributeValue.isEditable = !newAttributeValue.isEditable;
@@ -430,7 +434,11 @@ test('[LOCK-FIELDS] Insert&update array sub object element', async (t: Assertion
 		keepHistoric: true,
 	});
 
-	const attributesCreated: AttributeEntity[] = await (await mongoClient.updateManyAtOnce([attribute], 'userId1', true, false, 'code')).toArray();
+	const attributesCreated: AttributeEntity[] = await (await mongoClient.updateManyAtOnce([attribute], 'userId1', {
+		upsert: true,
+		lockNewFields: false,
+		query: 'code',
+	})).toArray();
 
 	const newAttributeValue = _.cloneDeep(attribute);
 	newAttributeValue.parameters.items[1].label['fr-FR'] = 'Autres tailles';
@@ -544,7 +552,11 @@ test('[LOCK-FIELDS] Insert&update attribute', async (t: Assertions) => {
 		keepHistoric: true,
 	});
 
-	const attributesCreated: AttributeEntity[] = await (await mongoClient.updateManyAtOnce([attribute], 'userId1', true, false, 'code')).toArray();
+	const attributesCreated: AttributeEntity[] = await (await mongoClient.updateManyAtOnce([attribute], 'userId1', {
+		upsert: true,
+		lockNewFields: false,
+		query: 'code',
+	})).toArray();
 	const attributeCreated = await mongoClient.findOneByKey(attribute.code);
 
 	t.deepEqual(attributesCreated[0], attributeCreated, `update many at once return new data`);

--- a/test/tests/unset-with-lock-field-enabled.ts
+++ b/test/tests/unset-with-lock-field-enabled.ts
@@ -66,7 +66,10 @@ test('[LOCK-FIELDS] Update multiple field with value to null', async (t: Asserti
 		property: {
 			value: null,
 		},
-	}], 'TEST', false, false, '_id');
+	}], 'TEST', {
+		lockNewFields: false,
+		query: '_id',
+	});
 
 	t.deepEqual((await entities.toArray())[0].property, { value: null }, 'value is deleted');
 });


### PR DESCRIPTION
This PR refactors the parameters of updateManyAtOnce with an object instead of a huge list of parameters. It also adds comments on these fields and on the method itself. Finally, it changes the query parameter: instead of a being a map of functions that will be called for each field of the query, it is now a single function that is called for the whole query.

Example:
```
// before
await this.mongoClient.updateManyAtOnce(entities, userId, true, false, {
	'body.id': (keyValue: any) => keyValue,
	'jobId': (keyValue: any) => MongoUtils.oid(keyValue),
});

// after
await this.mongoClient.updateManyAtOnce(entities, userId, {
	upsert: true,
	lockNewFields: false,
	query: (entity) => ({
		'body.id': entity.body.id,
		'jobId': MongoUtils.oid(entity.jobId),
	})
});
``
```