### PR TITLE
date: Fix date deletion during object prunation CATW-1100

### DIFF
--- a/src/lang-utils.ts
+++ b/src/lang-utils.ts
@@ -26,7 +26,9 @@ export class LangUtils {
 				removeEmptyObjects &&
 				_.isObject(objElement) &&
 				!_.isArray(objElement) &&
-				_.isEmpty(objElement)
+				_.isEmpty(objElement) &&
+				// _.isEmpty return true for Date instance
+				!_.isDate(objElement)
 			) {
 				delete obj[key];
 			}


### PR DESCRIPTION
`removeEmptyDeep` utils remove date from objet when called with `removeEmptyObjects` = true

This happens when we try to prune an object to remove locked fields from updateQuery