### PR TITLE
update: Add hooks in UpdateManyAtOnceOptions CATW-1758

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -1537,7 +1537,6 @@ export class MongoClient<U extends BaseMongoObject, L extends BaseMongoObject> {
 						delete newEntityMerged._id;
 
 						entity = newEntityMerged;
-						// TODO : add function parameter to allow validation here
 					}
 
 					if (options.lockNewFields) {
@@ -1571,6 +1570,10 @@ export class MongoClient<U extends BaseMongoObject, L extends BaseMongoObject> {
 							(entity as any)['objectInfos.lockFields'] = lockFields;
 						}
 					}
+				}
+
+				if (options.hooks?.mapAfterLockFieldsApplied) {
+					entity = await options.hooks.mapAfterLockFieldsApplied(entity);
 				}
 
 				const toSet = LodashReplacerUtils.OMIT_PROPERTIES(entity, options.onlyInsertFieldsKey);
@@ -1622,6 +1625,11 @@ export class MongoClient<U extends BaseMongoObject, L extends BaseMongoObject> {
 				if (options.mapFunction) {
 					entity = await options.mapFunction(entity);
 				}
+
+				if (options.hooks?.mapAfterLockFieldsApplied) {
+					entity = await options.hooks.mapAfterLockFieldsApplied(entity);
+				}
+
 				LangUtils.removeEmptyDeep(entity, undefined, undefined, !!this.conf.lockFields); // keep null values for lockfields
 
 				const toSet = LodashReplacerUtils.OMIT_PROPERTIES(entity, options.onlyInsertFieldsKey);

--- a/src/models/update-many-at-once-options.models.ts
+++ b/src/models/update-many-at-once-options.models.ts
@@ -28,6 +28,16 @@ export interface UpdateManyAtOnceOptions<U> {
 	mapFunction?:
 		| ((entity: Partial<U>, existingEntity?: U) => Promise<Partial<U>>)
 		| ((entity: Partial<U>, existingEntity?: U) => Partial<U>);
+	hooks?: {
+		/**
+		 * Function that will be used to map the entity after it has been merged with it's existing value.
+		 * The function will be called with the given entity merged with the existing entity (and it's locked values) if there is one.
+		 * Defaults to undefined (no mapping).
+		 */
+		mapAfterLockFieldsApplied?:
+			| ((entity: Partial<U>) => Promise<Partial<U>>)
+			| ((entity: Partial<U>) => Partial<U>);
+	};
 	/**
 	 * List of field keys in the entities that will only be added upon insertion.
 	 * Defaults to undefined.


### PR DESCRIPTION
Add optional `mapAfterLockFieldsApplied` hook in the _UpdateManyAtOnceOptions_ that is called during the **updateManyAtOnce** method.
It is called: 
- if it's and update, after existing entity is merged with entity using locked values;
- if it's an insert, after the `mapFunction` is called.