### PR TITLE
events: Hook on mongo events and log

### DIFF
--- a/benchmark.js
+++ b/benchmark.js
@@ -456,9 +456,8 @@ async function start() {
 	let mongod;
 
 	try {
-		mongod = new MongoMemoryServer();
-		const uri = await mongod.getConnectionString();
-		await MongoUtils.connect(uri);
+		mongod = await MongoMemoryServer.create();
+		await MongoUtils.connect(mongod.getUri());
 		const defaultCaseRunOptions = {
 			minSamples: 100,
 		};
@@ -472,8 +471,6 @@ async function start() {
 		await global.db.dropDatabase();
 		await runUpdateManyAtOnceHistoricBench(defaultCaseRunOptions, version);
 		await global.db.dropDatabase();
-	} catch (e) {
-		throw e;
 	} finally {
 		if (global.db) {
 			await global.db.dropDatabase();

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "class-transformer": "^0.4.0",
     "codecov": "^3.8.3",
     "husky": "^4.3.8",
-    "mongodb-memory-server": "6.9.6",
+    "mongodb-memory-server": "^7.6.3",
     "nyc": "^15.1.0",
     "prettier": "^2.6.2",
     "release-it": "^15.5.0",

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -6,6 +6,7 @@ export * from './historic.models';
 export * from './lock-field.models';
 export * from './maps.models';
 export * from './mongo-client-configuration.models';
+export * from './mongo-utils-options.models';
 export * from './tag-options.models';
 export * from './update-many-at-once-options.models';
 export * from './update-many-to-same-value-options.models';

--- a/src/models/mongo-utils-options.models.ts
+++ b/src/models/mongo-utils-options.models.ts
@@ -1,0 +1,8 @@
+export interface MongoUtilsOptions {
+	/**
+	 * On getting a reconnect failed event, should we kill the current processs
+	 *
+	 * @default true
+	 */
+	killProcessOnReconnectFailed?: boolean;
+}

--- a/test/errors.test.ts
+++ b/test/errors.test.ts
@@ -10,8 +10,7 @@ global.log = new N9Log('tests');
 
 ava('[Errors] Check error thrown on every client function', async (t: Assertions) => {
 	const mongoMemoryServer = await MongoMemoryServer.create();
-	await mongoMemoryServer.start();
-	const uri = await mongoMemoryServer.getUri();
+	const uri = mongoMemoryServer.getUri();
 
 	await t.notThrowsAsync(mongoMemoryServer.ensureInstance(), 'ensure mongo is up');
 

--- a/test/fixtures/utils.ts
+++ b/test/fixtures/utils.ts
@@ -51,12 +51,12 @@ export function init(): void {
 				global.log.warn(`Using MongoDB in memory`);
 				isInMemory = true;
 				// no classic mongodb available, so use one in memory
-				mongod = new MongoMemoryServer({
+				mongod = await MongoMemoryServer.create({
 					binary: {
 						version: '4.2.12',
 					},
 				});
-				mongoConnectionString = await mongod.getUri();
+				mongoConnectionString = mongod.getUri();
 				await MongoUtils.connect(mongoConnectionString);
 			} else {
 				throw e;

--- a/test/issues/issue-#1.test.ts
+++ b/test/issues/issue-#1.test.ts
@@ -24,8 +24,8 @@ global.log = new N9Log('tests').module('issues');
 let mongod: MongoMemoryServer;
 
 ava.before(async () => {
-	mongod = new MongoMemoryServer();
-	const uri = await mongod.getConnectionString();
+	mongod = await MongoMemoryServer.create();
+	const uri = mongod.getUri();
 	await MongoUtils.connect(uri);
 });
 

--- a/test/issues/issue-invalid-primitive-mapping.test.ts
+++ b/test/issues/issue-invalid-primitive-mapping.test.ts
@@ -18,8 +18,8 @@ class PrimitiveArrayHolder extends BaseMongoObject {
 let mongod: MongoMemoryServer;
 
 ava.before(async () => {
-	mongod = new MongoMemoryServer();
-	const uri = await mongod.getConnectionString();
+	mongod = await MongoMemoryServer.create();
+	const uri = mongod.getUri();
 	await MongoUtils.connect(uri);
 });
 

--- a/test/issues/issue-object-id.test.ts
+++ b/test/issues/issue-object-id.test.ts
@@ -11,8 +11,8 @@ global.log = new N9Log('tests').module('issues');
 let mongod: MongoMemoryServer;
 
 ava.before(async () => {
-	mongod = new MongoMemoryServer();
-	const uri = await mongod.getConnectionString();
+	mongod = await MongoMemoryServer.create();
+	const uri = mongod.getUri();
 	await MongoUtils.connect(uri);
 });
 

--- a/test/mongo-utils.test.ts
+++ b/test/mongo-utils.test.ts
@@ -1,4 +1,5 @@
 import { N9Log } from '@neo9/n9-node-log';
+import { waitFor } from '@neo9/n9-node-utils';
 import ava, { Assertions } from 'ava';
 import * as _ from 'lodash';
 import { ObjectID } from 'mongodb';
@@ -14,6 +15,14 @@ class SampleType extends BaseMongoObject {
 global.log = new N9Log('tests').module('mongo-utils');
 
 let mongod: MongoMemoryServer;
+
+ava.beforeEach('Enable log output mock', () => {
+	stdMocks.use();
+});
+
+ava.afterEach('Disable log output mock', () => {
+	stdMocks.restore();
+});
 
 ava('[MONGO-UTILS] disconnect without connect', async (t: Assertions) => {
 	t.deepEqual(await MongoUtils.disconnect(), undefined, 'should not block disconnect');
@@ -38,15 +47,14 @@ ava('[MONGO-UTILS] mapObjectToClass null', (t: Assertions) => {
 });
 
 ava('[MONGO-UTILS] URI connection log', async (t: Assertions) => {
-	mongod = new MongoMemoryServer();
-	const mongoURI = await mongod.getUri();
+	mongod = await MongoMemoryServer.create();
+	const mongoURI = mongod.getUri();
 	const mongoURIregex = new RegExp(_.escapeRegExp(mongoURI));
 
-	stdMocks.use();
 	await MongoUtils.connect(mongoURI);
 	await MongoUtils.disconnect();
+	await waitFor(500);
 	let output = stdMocks.flush();
-	stdMocks.restore();
 
 	t.regex(output.stdout[0], mongoURIregex, 'URI should be identic');
 
@@ -54,21 +62,88 @@ ava('[MONGO-UTILS] URI connection log', async (t: Assertions) => {
 	const mongoURIWithPassword = `mongodb://login:${mongoPassword}@localhost:27017/test-n9-mongo-client`;
 	const mongoURIPasswordRegex = new RegExp(_.escapeRegExp(mongoPassword));
 
-	stdMocks.use();
 	await t.throwsAsync(MongoUtils.connect(mongoURIWithPassword));
 	output = stdMocks.flush();
-	stdMocks.restore();
 
 	t.notRegex(output.stdout[0], mongoURIPasswordRegex, 'Password should not be displayed in URI');
+	t.regex(output.stdout[0], /localhost:27017\/test-n9-mongo-client/, 'Log should contain URI');
 
 	await mongod.stop();
 });
 
-ava('[MONGO-UTILS] List collection names', async (t: Assertions) => {
-	mongod = new MongoMemoryServer();
-	const mongoURI = await mongod.getUri();
+ava('[MONGO-UTILS] Ensure event logs', async (t: Assertions) => {
+	mongod = await MongoMemoryServer.create();
+	const mongoURI = mongod.getUri();
 
-	stdMocks.use({ print: false });
+	await MongoUtils.connect(mongoURI, {
+		autoReconnect: true,
+		reconnectTries: 100,
+		reconnectInterval: 50,
+	});
+	await waitFor(100);
+	let output = stdMocks.flush();
+
+	t.regex(output.stdout.pop(), /Client connected to/, 'Should have connection log');
+	t.truthy(global.dbClient.isConnected());
+
+	await mongod.stop(false);
+	await waitFor(100);
+	output = stdMocks.flush();
+
+	t.regex(output.stdout.pop(), /Client disconnected from/, 'Should have close event log');
+	t.falsy(global.dbClient.isConnected());
+
+	await mongod.start(true);
+	await waitFor(200);
+	output = stdMocks.flush();
+
+	t.regex(output.stdout.pop(), /Client reconnected to/, 'Should have reconnect event log');
+	t.truthy(global.dbClient.isConnected());
+
+	await MongoUtils.disconnect();
+	await MongoUtils.connect(mongoURI, {
+		socketTimeoutMS: 1,
+	});
+
+	await MongoUtils.listCollectionsNames();
+	await waitFor(10);
+	output = stdMocks.flush();
+
+	t.regex(
+		output.stdout.pop(),
+		/Client connection or operation timed out/,
+		'Should have timeout event log',
+	);
+
+	await MongoUtils.disconnect();
+	await MongoUtils.connect(
+		mongoURI,
+		{
+			autoReconnect: true,
+			reconnectTries: 1,
+			reconnectInterval: 50,
+		},
+		{ killProcessOnReconnectFailed: false },
+	);
+
+	await mongod.stop(false);
+	await waitFor(100);
+	output = stdMocks.flush();
+
+	t.regex(
+		output.stdout.pop(),
+		/Client reconnection failed/,
+		'Should have reconnect failed event log',
+	);
+	t.falsy(global.dbClient.isConnected());
+
+	await MongoUtils.disconnect();
+});
+
+ava('[MONGO-UTILS] List collection names', async (t: Assertions) => {
+	mongod = await MongoMemoryServer.create();
+	const mongoURI = mongod.getUri();
+
 	await MongoUtils.connect(mongoURI);
 
 	let names = await MongoUtils.listCollectionsNames();

--- a/yarn.lock
+++ b/yarn.lock
@@ -803,6 +803,14 @@
     "@types/bson" "*"
     "@types/node" "*"
 
+"@types/mongodb@^3.6.20":
+  version "3.6.20"
+  resolved "https://registry.yarnpkg.com/@types/mongodb/-/mongodb-3.6.20.tgz#b7c5c580644f6364002b649af1c06c3c0454e1d2"
+  integrity sha512-WcdpPJCakFzcWWD9juKoZbRtQxKIMYF/JIAM4JrNHrMcnJL6/a2NWjXxW7fo9hxboxxkg+icff8d7+WIEvKgYQ==
+  dependencies:
+    "@types/bson" "*"
+    "@types/node" "*"
+
 "@types/node@*":
   version "14.14.21"
   resolved "https://registry.npmjs.org/@types/node/-/node-14.14.21.tgz#d934aacc22424fe9622ebf6857370c052eae464e"
@@ -833,10 +841,10 @@
   resolved "https://registry.npmjs.org/@types/std-mocks/-/std-mocks-1.0.1.tgz#a5350e9e9c16af0157ab644337152fd6befe8baa"
   integrity sha512-pwOrGJ6jnqb1bw9TxrmbbHTI+7ngY8yEEkrTG7lJuwplvFT9XSwOCQC3Zb4E+e6g9yDzrFX+S1ysLZuT/07WYg==
 
-"@types/tmp@^0.2.0":
-  version "0.2.0"
-  resolved "https://registry.npmjs.org/@types/tmp/-/tmp-0.2.0.tgz#e3f52b4d7397eaa9193592ef3fdd44dc0af4298c"
-  integrity sha512-flgpHJjntpBAdJD43ShRosQvNC0ME97DCfGvZEDlAThQmnerRXrLbX6YgzRBQCZTthET9eAWFAMaYP0m0Y4HzQ==
+"@types/tmp@^0.2.2":
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.2.3.tgz#908bfb113419fd6a42273674c00994d40902c165"
+  integrity sha512-dDZH/tXzwjutnuk4UacGgFRwV+JSLaXL1ikvidfJprkb7L9Nx1njcRHHmi3Dsvt7pgqqTEeucQuOrWHPFgzVHA==
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -1176,6 +1184,13 @@ astral-regex@^2.0.0:
   resolved "https://registry.npmjs.org/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
+async-mutex@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/async-mutex/-/async-mutex-0.3.2.tgz#1485eda5bda1b0ec7c8df1ac2e815757ad1831df"
+  integrity sha512-HuTK7E7MT7jZEh1P9GtRW9+aTWiDWWi9InbZ5hjxrnRa39KS4BW04+xLBhYNS2aXhHUIKZSw3gj4Pn1pj+qGAA==
+  dependencies:
+    tslib "^2.3.1"
+
 async-retry@1.3.3:
   version "1.3.3"
   resolved "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz#0e7f36c04d8478e7a58bdbed80cedf977785f280"
@@ -1462,10 +1477,10 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   resolved "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.0.0:
-  version "6.2.0"
-  resolved "https://registry.npmjs.org/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
-  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
+camelcase@^6.1.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
+  integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
 
 camelcase@^7.0.0:
   version "7.0.0"
@@ -2089,6 +2104,13 @@ debug@^4.3.2, debug@^4.3.3:
   version "4.3.3"
   resolved "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz#04266e0b70a98d4462e6e288e38259213332b664"
   integrity sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==
+  dependencies:
+    ms "2.1.2"
+
+debug@^4.3.4:
+  version "4.3.4"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
+  integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
 
@@ -2792,7 +2814,7 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-find-cache-dir@^3.2.0, find-cache-dir@^3.3.1:
+find-cache-dir@^3.2.0:
   version "3.3.1"
   resolved "https://registry.npmjs.org/find-cache-dir/-/find-cache-dir-3.3.1.tgz#89b33fad4a4670daa94f855f7fbe31d6d84fe880"
   integrity sha512-t2GDMt3oGC/v+BMwzmllWDuJF/xcDtE5j/fCGbqDD7OLuJkj0cfh1YSA5VKPvwMeLFLNDBkwOKZ2X85jGLVftQ==
@@ -2801,10 +2823,14 @@ find-cache-dir@^3.2.0, find-cache-dir@^3.3.1:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
-find-package-json@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.npmjs.org/find-package-json/-/find-package-json-1.2.0.tgz#4057d1b943f82d8445fe52dc9cf456f6b8b58083"
-  integrity sha512-+SOGcLGYDJHtyqHd87ysBhmaeQ95oWspDKnMXBrnQ9Eq4OkLNqejgoaD8xVWu6GPa0B6roa6KinCMEMcVeqONw==
+find-cache-dir@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/find-cache-dir/-/find-cache-dir-3.3.2.tgz#b30c5b6eff0730731aea9bbd9dbecbd80256d64b"
+  integrity sha512-wXZV5emFEjrridIgED11OoUKLxiYjAcqot/NJdAkOhlJ+vGzwhOAfcG5OX1jP+S0PcjEn8bdMJv+g2jwQ3Onig==
+  dependencies:
+    commondir "^1.0.1"
+    make-dir "^3.0.2"
+    pkg-dir "^4.1.0"
 
 find-up@^2.0.0, find-up@^2.1.0:
   version "2.1.0"
@@ -4093,13 +4119,6 @@ locate-path@^7.1.0:
   dependencies:
     p-locate "^6.0.0"
 
-lockfile@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.npmjs.org/lockfile/-/lockfile-1.0.4.tgz#07f819d25ae48f87e538e6578b6964a4981a5609"
-  integrity sha512-cvbTwETRfsFh4nHsL1eGWapU1XFi5Ot9E85sWAwia7Y7EgB7vfqcZhTKZ+l7hCGxSPoushMv5GKhT5PdLv03WA==
-  dependencies:
-    signal-exit "^3.0.2"
-
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -4356,38 +4375,39 @@ modify-values@^1.0.0:
   resolved "https://registry.npmjs.org/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
 
-mongodb-memory-server-core@6.9.6:
-  version "6.9.6"
-  resolved "https://registry.npmjs.org/mongodb-memory-server-core/-/mongodb-memory-server-core-6.9.6.tgz#90ef0562bea675ef68bd687533792da02bcc81f3"
-  integrity sha512-ZcXHTI2TccH3L5N9JyAMGm8bbAsfLn8SUWOeYGHx/vDx7vu4qshyaNXTIxeHjpUQA29N+Z1LtTXA6vXjl1eg6w==
+mongodb-memory-server-core@7.6.3:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server-core/-/mongodb-memory-server-core-7.6.3.tgz#ba3ff2f50dc1cf5105683f15de54202976931af0"
+  integrity sha512-5rv79YlPoPvguRfFv1fvR78z69/QohGD+65f9UYWDfD70ykXpf6tAXPpWJ4ww/ues7FIVepkFCr3aiUvu6lA+A==
   dependencies:
-    "@types/tmp" "^0.2.0"
-    camelcase "^6.0.0"
-    cross-spawn "^7.0.3"
+    "@types/mongodb" "^3.6.20"
+    "@types/tmp" "^0.2.2"
+    async-mutex "^0.3.2"
+    camelcase "^6.1.0"
     debug "^4.2.0"
-    find-cache-dir "^3.3.1"
-    find-package-json "^1.2.0"
+    find-cache-dir "^3.3.2"
     get-port "^5.1.1"
     https-proxy-agent "^5.0.0"
-    lockfile "^1.0.4"
     md5-file "^5.0.0"
     mkdirp "^1.0.4"
-    semver "^7.3.2"
+    mongodb "^3.7.3"
+    new-find-package-json "^1.1.0"
+    semver "^7.3.5"
     tar-stream "^2.1.4"
     tmp "^0.2.1"
-    uuid "^8.3.0"
+    tslib "^2.3.0"
+    uuid "^8.3.1"
     yauzl "^2.10.0"
-  optionalDependencies:
-    mongodb "^3.6.2"
 
-mongodb-memory-server@6.9.6:
-  version "6.9.6"
-  resolved "https://registry.npmjs.org/mongodb-memory-server/-/mongodb-memory-server-6.9.6.tgz#ced1a100f58363317a562efaf8821726c433cfd2"
-  integrity sha512-BjGPPh5f61lMueG7px9DneBIrRR/GoWUHDvLWVAXhQhKVcwMMXxgeEba6zdDolZHfYAu6aYGPzhOuYKIKPgpBQ==
+mongodb-memory-server@^7.6.3:
+  version "7.6.3"
+  resolved "https://registry.yarnpkg.com/mongodb-memory-server/-/mongodb-memory-server-7.6.3.tgz#8b2827363ca16aaf250cba07f7a2b49e502735d4"
+  integrity sha512-yHDE9FGxOpSRUzitF9Qx3JjEgayCSJI3JOW2wgeBH/5PAsUdisy2nRxRiNwwLDooQ7tohllWCRTXlWqyarUEMQ==
   dependencies:
-    mongodb-memory-server-core "6.9.6"
+    mongodb-memory-server-core "7.6.3"
+    tslib "^2.3.0"
 
-mongodb@3.6.6, mongodb@^3.6.2:
+mongodb@3.6.6:
   version "3.6.6"
   resolved "https://registry.npmjs.org/mongodb/-/mongodb-3.6.6.tgz#92e3658f45424c34add3003e3046c1535c534449"
   integrity sha512-WlirMiuV1UPbej5JeCMqE93JRfZ/ZzqE7nJTwP85XzjAF4rRSeq2bGCb1cjfoHLOF06+HxADaPGqT0g3SbVT1w==
@@ -4396,6 +4416,19 @@ mongodb@3.6.6, mongodb@^3.6.2:
     bson "^1.1.4"
     denque "^1.4.1"
     optional-require "^1.0.2"
+    safe-buffer "^5.1.2"
+  optionalDependencies:
+    saslprep "^1.0.0"
+
+mongodb@^3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/mongodb/-/mongodb-3.7.3.tgz#b7949cfd0adc4cc7d32d3f2034214d4475f175a5"
+  integrity sha512-Psm+g3/wHXhjBEktkxXsFMZvd3nemI0r3IPsE0bU+4//PnvNWKkzhZcEsbPcYiWqe8XqXJJEg4Tgtr7Raw67Yw==
+  dependencies:
+    bl "^2.2.1"
+    bson "^1.1.4"
+    denque "^1.4.1"
+    optional-require "^1.1.8"
     safe-buffer "^5.1.2"
   optionalDependencies:
     saslprep "^1.0.0"
@@ -4439,6 +4472,14 @@ netmask@^2.0.2:
   version "2.0.2"
   resolved "https://registry.npmjs.org/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
   integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
+
+new-find-package-json@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/new-find-package-json/-/new-find-package-json-1.2.0.tgz#a2c0684c6539941a711d810acc5c3e9f076a7426"
+  integrity sha512-Z4v/wBxApGh1cCGEhNmq4p8wjDvM6R6vEuYzlAhzOlXBKLJfjyMvwd+ZHR9fyYKVvXfEn4Z3YX6MD470PxpVbQ==
+  dependencies:
+    debug "^4.3.4"
+    tslib "^2.4.0"
 
 new-github-release-url@2.0.0:
   version "2.0.0"
@@ -4649,6 +4690,13 @@ optional-require@^1.0.2:
   version "1.0.3"
   resolved "https://registry.npmjs.org/optional-require/-/optional-require-1.0.3.tgz#275b8e9df1dc6a17ad155369c2422a440f89cb07"
   integrity sha512-RV2Zp2MY2aeYK5G+B/Sps8lW5NHAzE5QClbFP15j+PWmP+T9PxlJXBOOLoSAdgwFvS4t0aMR4vpedMkbHfh0nA==
+
+optional-require@^1.1.8:
+  version "1.1.8"
+  resolved "https://registry.yarnpkg.com/optional-require/-/optional-require-1.1.8.tgz#16364d76261b75d964c482b2406cb824d8ec44b7"
+  integrity sha512-jq83qaUb0wNg9Krv1c5OQ+58EK+vHde6aBPzLvPPqJm89UQWsvSuFy9X/OSNJnFeSOKo7btE0n8Nl2+nE+z5nA==
+  dependencies:
+    require-at "^1.0.6"
 
 optionator@^0.8.1:
   version "0.8.3"
@@ -5411,6 +5459,11 @@ release-zalgo@^1.0.0:
   integrity sha1-CXALflB0Mpc5Mw5TXFqQ+2eFFzA=
   dependencies:
     es6-error "^4.0.1"
+
+require-at@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/require-at/-/require-at-1.0.6.tgz#9eb7e3c5e00727f5a4744070a7f560d4de4f6e6a"
+  integrity sha512-7i1auJbMUrXEAZCOQ0VNJgmcT2VOKPRl2YGJwgpHpC9CE91Mv4/4UYIUm4chGJaI381ZDq1JUicFii64Hapd8g==
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -6203,6 +6256,11 @@ tslib@^2.0.1, tslib@^2.1.0:
   resolved "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz#7cecaa7f073ce680a05847aa77be941098f36dc3"
   integrity sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==
 
+tslib@^2.3.0, tslib@^2.3.1, tslib@^2.4.0:
+  version "2.5.2"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.2.tgz#1b6f07185c881557b0ffa84b111a0106989e8338"
+  integrity sha512-5svOrSA2w3iGFDs1HibEVBGbDrAY82bFQ3HZ3ixB+88nsbsWQoKqDRb5UBYAUPEzbBn6dAp5gRNXglySbx1MlA==
+
 tsutils-etc@^1.4.1:
   version "1.4.1"
   resolved "https://registry.npmjs.org/tsutils-etc/-/tsutils-etc-1.4.1.tgz#bd42a0079d534765ab314d087f8a89c77a68723f"
@@ -6392,7 +6450,7 @@ uuid@^3.3.3:
   resolved "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
-uuid@^8.0.0, uuid@^8.3.0:
+uuid@^8.0.0, uuid@^8.3.1:
   version "8.3.2"
   resolved "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==


### PR DESCRIPTION
- Hook to some mongo events and log when event fired.
- Add tests to ensure logs are OK.
- Update mongo-memory-server to v7.6.3 so we can reuse port immediatly after stopping server (cf [mongodb-memory-server issue 330](https://github.com/nodkz/mongodb-memory-server/issues/330))