### PR TITLE
locks: Fix missing locks on array order changed

### DIFF
--- a/test/fixtures/utils.ts
+++ b/test/fixtures/utils.ts
@@ -7,7 +7,9 @@ import { BaseMongoObject, StringMap } from '../../src/models';
 
 export class ArrayElement {
 	public code: string;
-	public label: StringMap<string>;
+	public otherCode?: string;
+	public label?: StringMap<string>;
+	public value?: string | number | boolean;
 }
 
 export class SampleEntityWithArray extends BaseMongoObject {
@@ -30,6 +32,22 @@ export function generateMongoClient(): MongoClient<SampleEntityWithArray, null> 
 		lockFields: {
 			arrayWithReferences: {
 				'parameters.items': ['code', 'otherCode'],
+			},
+			excludedFields: ['code'],
+		},
+		keepHistoric: true,
+	});
+}
+
+export function generateMongoClientForSimpleArray(): MongoClient<
+	SampleEntityWithSimpleArray,
+	null
+> {
+	const collectionName = `test-${Math.ceil(Math.random() * 10000)}-${Date.now()}`;
+	return new MongoClient(collectionName, SampleEntityWithSimpleArray, null, {
+		lockFields: {
+			arrayWithReferences: {
+				'parameters.items': [],
 			},
 			excludedFields: ['code'],
 		},

--- a/test/lock-fields-arrays-b.test.ts
+++ b/test/lock-fields-arrays-b.test.ts
@@ -2,7 +2,13 @@ import { N9Log } from '@neo9/n9-node-log';
 import ava, { Assertions } from 'ava';
 import * as _ from 'lodash';
 
-import { generateMongoClient, init, SampleEntityWithArray } from './fixtures/utils';
+import {
+	generateMongoClient,
+	generateMongoClientForSimpleArray,
+	init,
+	SampleEntityWithArray,
+	SampleEntityWithSimpleArray,
+} from './fixtures/utils';
 
 global.log = new N9Log('tests').module('lock-fields-arrays');
 
@@ -14,6 +20,7 @@ const a = {
 		'en-GB': 'Label en a',
 		'fr-FR': 'Label fr a',
 	},
+	value: true,
 };
 const b = {
 	code: 'b',
@@ -21,6 +28,7 @@ const b = {
 		'en-GB': 'Label en b',
 		'fr-FR': 'Label fr b',
 	},
+	value: true,
 };
 const c = {
 	code: 'c',
@@ -28,6 +36,31 @@ const c = {
 		'en-GB': 'Label en c',
 		'fr-FR': 'Label fr c',
 	},
+	value: true,
+};
+const d = {
+	code: 'd',
+	label: {
+		'en-GB': 'Label en d',
+		'fr-FR': 'Label fr d',
+	},
+	value: true,
+};
+const e = {
+	code: 'e',
+	label: {
+		'en-GB': 'Label en e',
+		'fr-FR': 'Label fr e',
+	},
+	value: true,
+};
+const f = {
+	code: 'f',
+	label: {
+		'en-GB': 'Label en f',
+		'fr-FR': 'Label fr f',
+	},
+	value: true,
 };
 
 /**
@@ -49,10 +82,12 @@ ava(
 		const bLockPaths = [
 			'parameters.items[code=c].label.en-GB',
 			'parameters.items[code=c].label.fr-FR',
+			'parameters.items[code=c].value',
 			'parameters.items[code=b].label.en-GB',
 			'parameters.items[code=b].label.fr-FR',
 			'parameters.items[code=a].label.en-GB',
 			'parameters.items[code=a].label.fr-FR',
+			'parameters.items[code=a].value',
 		];
 
 		const vB: SampleEntityWithArray = {
@@ -103,7 +138,7 @@ ava(
 			bLockPaths,
 			'[newValue2] Lock field b',
 		);
-		t.is(newValue2.objectInfos.lockFields.length, 6, '[newValue2] b is locked');
+		t.is(newValue2.objectInfos.lockFields.length, 8, '[newValue2] b is locked');
 
 		const vBpp = _.cloneDeep(vB);
 		vBpp.parameters.items = [b, c, a];
@@ -126,5 +161,260 @@ ava(
 			'[resultImport2] Lock field b still alone',
 		);
 		t.deepEqual(resultImport2[0].parameters.items[1], bp, '[resultImport2] bp Label kept');
+	},
+);
+
+/**
+ * B :  [d,e,f]
+ * B':  [e,f,d]
+ * B'': [d,e,f]
+ *
+ * Import de B =>  aucun verrou => [d,e,f]
+ * Modification opérateur de B par B' => d, e et f vérouillés par changement de place => [e🔒,f🔒,d🔒]
+ * Import de B" => d, e et f toujours vérouillés et ordre n'a pas changé => [e🔒,f🔒,d🔒]
+ */
+ava('[LOCK-FIELDS-ARRAY B] Import, change all order, re-import datas', async (t: Assertions) => {
+	const bLockPaths = [
+		'parameters.items[code=e].label.en-GB',
+		'parameters.items[code=e].label.fr-FR',
+		'parameters.items[code=e].value',
+		'parameters.items[code=f].label.en-GB',
+		'parameters.items[code=f].label.fr-FR',
+		'parameters.items[code=f].value',
+		'parameters.items[code=d].label.en-GB',
+		'parameters.items[code=d].label.fr-FR',
+		'parameters.items[code=d].value',
+	];
+
+	const vB: SampleEntityWithArray = {
+		code: 'b',
+		parameters: {
+			items: [d, e, f],
+		},
+	};
+
+	const mongoClient = generateMongoClient();
+	await mongoClient.initHistoricIndexes();
+
+	// Simulate import
+	const resultImport1: SampleEntityWithArray[] = await (
+		await mongoClient.updateManyAtOnce([vB], 'externalUser', {
+			upsert: true,
+			lockNewFields: false,
+			query: 'code',
+		})
+	).toArray();
+	t.deepEqual(
+		_.map(resultImport1[0].parameters.items, 'code'),
+		['d', 'e', 'f'],
+		'[resultImport1] All values saved',
+	);
+
+	const vBp = _.cloneDeep(vB);
+	// move a to the end of array
+	vBp.parameters.items = [e, f, d];
+
+	// operator update
+	const newValue2 = await mongoClient.findOneAndUpdateByIdWithLocks(
+		resultImport1[0]._id,
+		vBp,
+		'userIdUpdate',
+		true,
+		true,
+	);
+	t.deepEqual(
+		_.map(newValue2.parameters.items, 'code'),
+		['e', 'f', 'd'],
+		'[newValue2] Check value updated',
+	);
+	t.truthy(newValue2.objectInfos.lockFields, '[newValue2] Has lock fields');
+	t.is(newValue2.objectInfos.lockFields.length, 9, '[newValue2] all item keys are locked');
+	t.deepEqual(
+		_.map(newValue2.objectInfos.lockFields, 'path'),
+		bLockPaths,
+		'[newValue2] Check lock fields',
+	);
+
+	const vBpp = _.cloneDeep(vB);
+	vBpp.parameters.items = [d, e, f];
+	// Simulate import
+	const resultImport2: SampleEntityWithArray[] = await (
+		await mongoClient.updateManyAtOnce([vBpp], 'externalUser', {
+			upsert: true,
+			lockNewFields: false,
+			query: 'code',
+		})
+	).toArray();
+	t.deepEqual(
+		_.map(resultImport2[0].parameters.items, 'code'),
+		['e', 'f', 'd'],
+		'[resultImport2] Order should not have changed',
+	);
+	t.deepEqual(
+		_.map(resultImport2[0].objectInfos.lockFields, 'path'),
+		bLockPaths,
+		'[resultImport2] Check lock fields are still the same',
+	);
+});
+
+/**
+ * B :  [a,b,c]
+ * B':  [c,b,a]
+ * B'': [b,c,a]
+ *
+ * Import de B =>  aucun verrou => [a,b,c]
+ * Modification opérateur de B par B' => c et a vérrouillés par changement de place => [c🔒,b,a🔒]
+ * Import de B" => a, b c toujours vérouillés et ordre conservé => [c🔒,a🔒,b]
+ */
+ava(
+	'[LOCK-FIELDS-ARRAY B] Import, change order, re-import datas with simple array',
+	async (t: Assertions) => {
+		const bLockPaths = ['parameters.items["c"]', 'parameters.items["a"]'];
+
+		const vB: SampleEntityWithSimpleArray = {
+			code: 'b',
+			parameters: {
+				items: ['a', 'b', 'c'],
+			},
+		};
+		const mongoClient = generateMongoClientForSimpleArray();
+		await mongoClient.initHistoricIndexes();
+
+		// Simulate import
+		const resultImport1: SampleEntityWithSimpleArray[] = await (
+			await mongoClient.updateManyAtOnce([vB], 'externalUser', {
+				upsert: true,
+				lockNewFields: false,
+				query: 'code',
+			})
+		).toArray();
+		t.deepEqual(
+			resultImport1[0].parameters.items,
+			['a', 'b', 'c'],
+			'[resultImport1] All values saved',
+		);
+
+		const vBp = _.cloneDeep(vB);
+		// change order and edit b to bp
+		vBp.parameters.items = ['c', 'b', 'a'];
+
+		// operator update
+		const newValue2 = await mongoClient.findOneAndUpdateByIdWithLocks(
+			resultImport1[0]._id,
+			vBp,
+			'userIdUpdate',
+			true,
+			true,
+		);
+		t.deepEqual(newValue2.parameters.items, ['c', 'b', 'a'], '[newValue2] Order updated');
+		t.truthy(newValue2.objectInfos.lockFields, '[newValue2] Has lock fields');
+		t.is(newValue2.objectInfos.lockFields.length, 2, '[newValue2] Should have only 2 locked paths');
+		t.deepEqual(
+			_.map(newValue2.objectInfos.lockFields, 'path'),
+			bLockPaths,
+			'[newValue2] A and B should be locked',
+		);
+
+		const vBpp = _.cloneDeep(vB);
+		vBpp.parameters.items = ['b', 'c', 'a'];
+		// Simulate import
+		const resultImport2: SampleEntityWithSimpleArray[] = await (
+			await mongoClient.updateManyAtOnce([vBpp], 'externalUser', {
+				upsert: true,
+				lockNewFields: false,
+				query: 'code',
+			})
+		).toArray();
+		t.deepEqual(
+			resultImport2[0].parameters.items,
+			['c', 'a', 'b'],
+			'[resultImport2] All values saved, locked items c and a should be first',
+		);
+		t.deepEqual(
+			_.map(resultImport2[0].objectInfos.lockFields, 'path'),
+			bLockPaths,
+			'[resultImport2] b still not locked',
+		);
+	},
+);
+
+/**
+ * B :  [a,b,c]
+ * B':  [b,c,a]
+ * B'': [a,b,c]
+ *
+ * Import de B =>  aucun verrou => [a,b,c]
+ * Modification opérateur de B par B' => a, b et c vérouillés par changement de place => [b🔒,c🔒,a🔒]
+ * Import de B" => a, b et c toujours vérouillés et ordre n'a pas changé => [b🔒,c🔒,a🔒]
+ */
+ava(
+	'[LOCK-FIELDS-ARRAY B] Import, change all order, re-import datas with simple array',
+	async (t: Assertions) => {
+		const bLockPaths = ['parameters.items["b"]', 'parameters.items["c"]', 'parameters.items["a"]'];
+
+		const vB: SampleEntityWithSimpleArray = {
+			code: 'b',
+			parameters: {
+				items: ['a', 'b', 'c'],
+			},
+		};
+		const mongoClient = generateMongoClientForSimpleArray();
+		await mongoClient.initHistoricIndexes();
+
+		// Simulate import
+		const resultImport1: SampleEntityWithSimpleArray[] = await (
+			await mongoClient.updateManyAtOnce([vB], 'externalUser', {
+				upsert: true,
+				lockNewFields: false,
+				query: 'code',
+			})
+		).toArray();
+		t.deepEqual(
+			resultImport1[0].parameters.items,
+			['a', 'b', 'c'],
+			'[resultImport1] All values saved',
+		);
+
+		const vBp = _.cloneDeep(vB);
+		// move a to the end of array
+		vBp.parameters.items = ['b', 'c', 'a'];
+
+		// operator update
+		const newValue2 = await mongoClient.findOneAndUpdateByIdWithLocks(
+			resultImport1[0]._id,
+			vBp,
+			'userIdUpdate',
+			true,
+			true,
+		);
+		t.deepEqual(newValue2.parameters.items, ['b', 'c', 'a'], '[newValue2] Order updated');
+		t.truthy(newValue2.objectInfos.lockFields, '[newValue2] Has lock fields');
+		t.is(newValue2.objectInfos.lockFields.length, 3, '[newValue2] All items are locked');
+		t.deepEqual(
+			_.map(newValue2.objectInfos.lockFields, 'path'),
+			bLockPaths,
+			'[newValue2] a, b and c should be locked',
+		);
+
+		const vBpp = _.cloneDeep(vB);
+		vBpp.parameters.items = ['a', 'b', 'c'];
+		// Simulate import
+		const resultImport2: SampleEntityWithSimpleArray[] = await (
+			await mongoClient.updateManyAtOnce([vBpp], 'externalUser', {
+				upsert: true,
+				lockNewFields: false,
+				query: 'code',
+			})
+		).toArray();
+		t.deepEqual(
+			resultImport2[0].parameters.items,
+			['b', 'c', 'a'],
+			'[resultImport2] Order should not have changed',
+		);
+		t.deepEqual(
+			_.map(resultImport2[0].objectInfos.lockFields, 'path'),
+			bLockPaths,
+			'[resultImport2] a, b and c should still be locked',
+		);
 	},
 );

--- a/test/lock-fields-arrays-e.test.ts
+++ b/test/lock-fields-arrays-e.test.ts
@@ -2,9 +2,9 @@ import { N9Log } from '@neo9/n9-node-log';
 import ava, { Assertions } from 'ava';
 import * as _ from 'lodash';
 
-import { MongoClient } from '../src';
 import {
 	generateMongoClient,
+	generateMongoClientForSimpleArray,
 	init,
 	SampleEntityWithArray,
 	SampleEntityWithSimpleArray,
@@ -154,13 +154,7 @@ ava(
 			},
 		};
 
-		const collectionName = `test-${Math.ceil(Math.random() * 10000)}-${Date.now()}`;
-		const mongoClient = new MongoClient(collectionName, SampleEntityWithSimpleArray, null, {
-			lockFields: {
-				excludedFields: ['code'],
-			},
-			keepHistoric: true,
-		});
+		const mongoClient = generateMongoClientForSimpleArray();
 		await mongoClient.initHistoricIndexes();
 
 		// Simulate user creation

--- a/test/lock-fields-disabled.test.ts
+++ b/test/lock-fields-disabled.test.ts
@@ -4,12 +4,7 @@ import * as _ from 'lodash';
 
 import { MongoClient } from '../src';
 import { BaseMongoObject } from '../src/models';
-import { init } from './fixtures/utils';
-
-class ArrayElement {
-	public code: string;
-	public value: string;
-}
+import { ArrayElement, init } from './fixtures/utils';
 
 class SampleComplexType extends BaseMongoObject {
 	public text: string;

--- a/test/lock-fields-dont-change-undefined.test.ts
+++ b/test/lock-fields-dont-change-undefined.test.ts
@@ -5,12 +5,7 @@ import { ObjectId } from 'mongodb';
 
 import { MongoClient, MongoUtils } from '../src';
 import { BaseMongoObject } from '../src/models';
-import { init } from './fixtures/utils';
-
-class ArrayElement {
-	public code: string;
-	public value: string;
-}
+import { ArrayElement, init } from './fixtures/utils';
 
 class SampleComplexType extends BaseMongoObject {
 	public text: string;


### PR DESCRIPTION
Fix issue where, when we have an entity with an array of objects with some fields that are the same, when updating the order, the fields were not locked.

Example (with code being a reference):
``` typescript
before = { items: [{code: 'a', value: 'toto' }, { code: 'b', value: 'toto' }, { code: 'c', value: 'toto' }] }
after = { items: [{ code: 'b', value: 'toto' }, { code: 'c', value: 'toto' }, {code: 'a', value: 'toto' }] }
```

expected lockfields:
```
items[code=a].value
items[code=b].value
items[code=c].value
```

result lockfields:
```
items[code=a]
items[code=b]
items[code=c]
```